### PR TITLE
net_io_counters: do not restart from zero

### DIFF
--- a/autologin.py
+++ b/autologin.py
@@ -73,7 +73,7 @@ def try_login(logins):
 
 
 def get_net_used():
-    counter = psutil.net_io_counters()
+    counter = psutil.net_io_counters(nowrap=True)
     return counter.bytes_sent + counter.bytes_recv
 
 


### PR DESCRIPTION
From the [psutil docs](https://psutil.readthedocs.io/en/latest/#psutil.net_io_counters) for net_io_counters,

> On some systems such as Linux, on a very busy or long-lived system, the numbers returned by the kernel may overflow and wrap (restart from zero). If _nowrap_ is `True` psutil will detect and adjust those numbers across function calls and add “old value” to “new value” so that the returned numbers will always be increasing or remain the same, but never decrease


As we [depend on the values returned](https://github.com/iamkroot/sophos-autologin/blob/1b945f169a0e766ec382e39c4a5fd8d62bba7e92/autologin.py#L99) to calculate the used data, it's desirable to set the _nowrap_ parameter to `True`.